### PR TITLE
Remove sign-up option from login

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,16 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Logo from '@/components/ui/Logo';
-import RegisterForm from '@/components/auth/RegisterForm';
 import LoginForm from '@/components/auth/LoginForm';
 import { useTranslations } from 'next-intl';
 
 export default function Home() {
   const t = useTranslations();
-  const [showLogin, setShowLogin] = useState(true);
   const { status } = useSession();
   const router = useRouter();
 
@@ -20,9 +18,6 @@ export default function Home() {
     }
   }, [status, router]);
 
-  const toggleForm = () => {
-    setShowLogin(!showLogin);
-  };
 
   if (status === 'loading') {
     return (
@@ -56,11 +51,7 @@ export default function Home() {
 
       {/* Right Section */}
       <div className="w-full lg:w-1/2 bg-white p-8 lg:p-12 flex flex-col justify-center">
-        {showLogin ? (
-          <LoginForm onToggleForm={toggleForm} />
-        ) : (
-          <RegisterForm onToggleForm={toggleForm} />
-        )}
+        <LoginForm />
       </div>
     </main>
   );

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -10,11 +10,7 @@ import Input from "../ui/Input";
 import { LoginInput, loginSchema } from "@/lib/validations/auth";
 import { useTranslations } from 'next-intl';
 
-export default function LoginForm({
-  onToggleForm,
-}: {
-  onToggleForm: () => void;
-}) {
+export default function LoginForm() {
   const t = useTranslations();
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -96,14 +92,6 @@ export default function LoginForm({
             }}
           >
             {t('auth.login.forgotPassword')}
-          </button>
-          <span className="mx-2">|</span>
-          <button
-            type="button"
-            className="text-sm text-blue-600 hover:underline"
-            onClick={onToggleForm}
-          >
-            {t('auth.login.noAccount')} {t('auth.login.createAccount')}
           </button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- strip registration link and form toggle from `LoginForm`
- display only the login form on the home page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5e8880ac833388cc3b0876fac4d3